### PR TITLE
Fix wrong API level

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -36,7 +36,7 @@ android {
     compileSdkVersion 27
     buildToolsVersion '27.0.3'
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 27
     }
     compileOptions {


### PR DESCRIPTION
fix for:
```
Camera2VideoFragment.java:814: Error: Call requires API level 24 (current min is 23): android.media.MediaRecorder#pause [NewApi]
      mMediaRecorder.pause();
                     ~~~~~
```