### PR TITLE
Log list of available capture resolution

### DIFF
--- a/Application/src/main/java/com/example/android/camera2video/Camera2VideoFragment.java
+++ b/Application/src/main/java/com/example/android/camera2video/Camera2VideoFragment.java
@@ -131,6 +131,7 @@ public class Camera2VideoFragment extends Fragment
   private final Semaphore mCameraOpenCloseLock = new Semaphore(1);
   private Range<Integer>[] mAvailableHighSpeedFps;
   private Range<Integer>[] mAvailableFps;
+  private Size[] mAvailableResolutions;
   private Integer mSensorOrientation;
   private CaptureRequest.Builder mPreviewBuilder;
   private IntentFilter mRecordIntent;
@@ -509,7 +510,8 @@ public class Camera2VideoFragment extends Fragment
 
       StreamConfigurationMap configs = characteristics.get(
           CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
-      Size[] sizes = configs.getOutputSizes(MediaCodec.class);
+      mAvailableResolutions = configs.getOutputSizes(MediaCodec.class);
+      Log.i(TAG, "Available capture resolutions: " + Arrays.toString(mAvailableResolutions));
 
       mCameraSize = getRequestedVideoSize(
           map.getOutputSizes(SurfaceTexture.class),
@@ -729,6 +731,17 @@ public class Camera2VideoFragment extends Fragment
     return false;
   }
 
+  private boolean isResolutionSupported(int width, int height) {
+    for (Size res : mAvailableResolutions) {
+      if (Math.max(width, height) == Math.max(res.getWidth(), res.getHeight())
+          && Math.min(width, height) == Math.min(res.getWidth(), res.getHeight())) {
+        return true;
+      }
+    }
+    Log.e(TAG, "Resolution [" + width + "x" + height + "] not supported");
+    return false;
+  }
+
   private void setUpMediaRecorder(
       final String recordingFilename,
       final int captureFps,
@@ -755,7 +768,8 @@ public class Camera2VideoFragment extends Fragment
       width = captureVideoWidth;
       height = captureVideoHeight;
     }
-    Log.i(TAG, "Capture resolution: " + captureVideoWidth + "x" + captureVideoHeight);
+    Log.i(TAG, "Capture resolution: " + width + "x" + height);
+    isResolutionSupported(width, height);
     mMediaRecorder.setVideoSize(width, height);
     mMediaRecorder.setVideoEncoder(MediaRecorder.VideoEncoder.H264);
     mMediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);

--- a/Application/src/main/java/com/example/android/camera2video/Camera2VideoFragment.java
+++ b/Application/src/main/java/com/example/android/camera2video/Camera2VideoFragment.java
@@ -740,7 +740,7 @@ public class Camera2VideoFragment extends Fragment
       height = captureVideoHeight;
     }
     Log.i(TAG, "Capture resolution: " + captureVideoWidth + "x" + captureVideoHeight);
-    mMediaRecorder.setVideosize(width, height);
+    mMediaRecorder.setVideoSize(width, height);
     mMediaRecorder.setVideoEncoder(MediaRecorder.VideoEncoder.H264);
     mMediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
 


### PR DESCRIPTION
Test:

logcat:
```
02-21 16:23:18.890 17153 17153 I Camera2VideoFragment: Available capture resolutions: [4032x3024, 4000x3000, 4000x2000, 3840x2160, 3264x2448, 2688x1512, 2688x1344, 2592x1944, 2048x1536, 1920x1440, 1920x1080, 1600x1200, 1920x960, 1280x960, 1280x768, 1280x720, 1024x768, 800x400, 800x600, 800x480, 720x480, 640x480, 640x400, 640x360, 352x288, 320x240, 176x144]
02-21 16:23:48.656 17153 17153 I Camera2VideoFragment: Capture resolution: 720x10
02-21 16:23:48.657 17153 17153 E Camera2VideoFragment: Resolution [720x10] not supported
```